### PR TITLE
Fix 7 audit findings

### DIFF
--- a/src/srvaudit/checks/capabilities.py
+++ b/src/srvaudit/checks/capabilities.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import List
 
 from srvaudit.checks.registry import BaseCheck, check
-from srvaudit.models import Finding
+from srvaudit.models import Finding, Severity
 
 DANGEROUS_CAPS = {
     "cap_setuid",
@@ -25,12 +25,15 @@ KNOWN_SAFE = {
     "/usr/sbin/arping",
 }
 
+RESULT_LIMIT = 50
+DETAIL_LIMIT = 10
+
 
 @check(name="capabilities", category="system", requires_sudo=True)
 class CapabilitiesCheck(BaseCheck):
     def run(self) -> List[Finding]:
         findings = []
-        result = self.execute("getcap -r / 2>/dev/null | head -50")
+        result = self.execute(f"getcap -r / 2>/dev/null | head -{RESULT_LIMIT}")
         if result.not_found:
             findings.append(self.skip("getcap not available"))
             return findings
@@ -39,9 +42,12 @@ class CapabilitiesCheck(BaseCheck):
             return findings
 
         suspicious = []
-        for line in result.stdout.splitlines():
+        raw_lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+        truncated = len(raw_lines) == RESULT_LIMIT
+
+        for line in raw_lines:
             line = line.strip()
-            if not line or "=" not in line:
+            if "=" not in line:
                 continue
             parts = line.split("=", 1)
             filepath = parts[0].strip()
@@ -55,10 +61,23 @@ class CapabilitiesCheck(BaseCheck):
                 suspicious.append(f"{filepath} = {caps}")
 
         if suspicious:
+            details = "\n".join(suspicious[:DETAIL_LIMIT])
+            if truncated:
+                note = f"(showing first {RESULT_LIMIT} results, may be incomplete)"
+                details = f"{details}\n{note}" if details else note
             findings.append(
                 self.warning(
                     f"{len(suspicious)} files with dangerous capabilities",
-                    details="\n".join(suspicious[:10]),
+                    details=details,
+                )
+            )
+        elif truncated:
+            findings.append(
+                Finding(
+                    check=self._check_meta.name,
+                    severity=Severity.OK,
+                    title="No suspicious file capabilities",
+                    details=f"(showing first {RESULT_LIMIT} results, may be incomplete)",
                 )
             )
         else:

--- a/src/srvaudit/checks/cron.py
+++ b/src/srvaudit/checks/cron.py
@@ -5,6 +5,11 @@ from typing import List
 from srvaudit.checks.registry import BaseCheck, check
 from srvaudit.models import Finding
 
+USER_LIMIT = 20
+SYSTEM_CRON_LIMIT = 20
+DETAIL_LIMIT = 10
+JOB_DETAIL_LIMIT = 5
+
 
 @check(name="cron", category="persistence", requires_sudo=True)
 class CronCheck(BaseCheck):
@@ -17,13 +22,15 @@ class CronCheck(BaseCheck):
     def _check_user_crontabs(self, findings: list):
         # Get users with login shells
         users_result = self.execute(
-            "getent passwd | awk -F: '$7 !~ /(nologin|false)/ {print $1}' | head -20"
+            f"getent passwd | awk -F: '$7 !~ /(nologin|false)/ {{print $1}}' | head -{USER_LIMIT}"
         )
         if not users_result.success:
             return
 
-        for user in users_result.stdout.splitlines():
-            user = user.strip()
+        users = [user.strip() for user in users_result.stdout.splitlines() if user.strip()]
+        users_truncated = len(users) == USER_LIMIT
+
+        for user in users:
             if not user or user in ("$", "#") or not all(c.isalnum() or c in "-_." for c in user):
                 continue
             result = self.execute(f"crontab -l -u {user} 2>/dev/null")
@@ -34,15 +41,19 @@ class CronCheck(BaseCheck):
                     if line.strip() and not line.strip().startswith("#")
                 ]
                 if jobs:
+                    details = "\n".join(jobs[:JOB_DETAIL_LIMIT])
+                    if users_truncated:
+                        note = f"(showing first {USER_LIMIT} results, may be incomplete)"
+                        details = f"{details}\n{note}" if details else note
                     findings.append(
                         self.info(
                             f"{user}: {len(jobs)} cron job(s)",
-                            details="\n".join(jobs[:5]),
+                            details=details,
                         )
                     )
 
     def _check_system_cron(self, findings: list):
-        result = self.execute("ls /etc/cron.d/ 2>/dev/null | head -20")
+        result = self.execute(f"ls /etc/cron.d/ 2>/dev/null | head -{SYSTEM_CRON_LIMIT}")
         if result.success and result.stdout.strip():
             files = [
                 f.strip()
@@ -50,9 +61,15 @@ class CronCheck(BaseCheck):
                 if f.strip() and f.strip() not in (".placeholder", "e2scrub_all")
             ]
             if files:
+                details = ", ".join(files[:DETAIL_LIMIT])
+                if len(files) == SYSTEM_CRON_LIMIT:
+                    note = (
+                        f"(showing first {SYSTEM_CRON_LIMIT} results, may be incomplete)"
+                    )
+                    details = f"{details}\n{note}" if details else note
                 findings.append(
                     self.info(
                         f"{len(files)} system cron files in /etc/cron.d/",
-                        details=", ".join(files[:10]),
+                        details=details,
                     )
                 )

--- a/src/srvaudit/checks/cron.py
+++ b/src/srvaudit/checks/cron.py
@@ -63,9 +63,7 @@ class CronCheck(BaseCheck):
             if files:
                 details = ", ".join(files[:DETAIL_LIMIT])
                 if len(files) == SYSTEM_CRON_LIMIT:
-                    note = (
-                        f"(showing first {SYSTEM_CRON_LIMIT} results, may be incomplete)"
-                    )
+                    note = f"(showing first {SYSTEM_CRON_LIMIT} results, may be incomplete)"
                     details = f"{details}\n{note}" if details else note
                 findings.append(
                     self.info(

--- a/src/srvaudit/checks/dotenv.py
+++ b/src/srvaudit/checks/dotenv.py
@@ -5,6 +5,9 @@ from typing import List
 from srvaudit.checks.registry import BaseCheck, check
 from srvaudit.models import Finding
 
+RESULT_LIMIT = 10
+DETAIL_LIMIT = 5
+
 
 @check(name="dotenv", category="web")
 class DotenvCheck(BaseCheck):
@@ -17,17 +20,21 @@ class DotenvCheck(BaseCheck):
             return findings
 
         result = self.execute(
-            "find /var/www -maxdepth 3 -name '.env' -type f 2>/dev/null | head -10"
+            f"find /var/www -maxdepth 3 -name '.env' -type f 2>/dev/null | head -{RESULT_LIMIT}"
         )
         if not result.success or not result.stdout.strip():
             return findings
 
         files = [f.strip() for f in result.stdout.splitlines() if f.strip()]
         if files:
+            details = "\n".join(files[:DETAIL_LIMIT])
+            if len(files) == RESULT_LIMIT:
+                note = f"(showing first {RESULT_LIMIT} results, may be incomplete)"
+                details = f"{details}\n{note}" if details else note
             findings.append(
                 self.warning(
                     f"{len(files)} .env file(s) found in web directories",
-                    details="\n".join(files[:5]),
+                    details=details,
                     fix_command=("# Add to nginx config:\n# location ~ /\\.env { deny all; }"),
                 )
             )

--- a/src/srvaudit/checks/fail2ban.py
+++ b/src/srvaudit/checks/fail2ban.py
@@ -65,7 +65,10 @@ class Fail2banCheck(BaseCheck):
         return findings
 
     def _is_ssh_exposed(self) -> bool:
-        result = self.execute("ss -tlnp 2>/dev/null | grep ':22 '")
+        result = self.execute("ss -tlnp 2>/dev/null | grep sshd")
         if result.success and result.stdout.strip():
-            return "0.0.0.0" in result.stdout or "*:" in result.stdout or ":::" in result.stdout
+            return any(
+                "0.0.0.0:" in line or "*:" in line or ":::" in line
+                for line in result.stdout.splitlines()
+            )
         return False

--- a/src/srvaudit/checks/updates.py
+++ b/src/srvaudit/checks/updates.py
@@ -11,11 +11,26 @@ class UpdatesCheck(BaseCheck):
     def run(self) -> List[Finding]:
         if self.distro.is_debian_family:
             return self._check_apt()
-        elif self.distro.is_rhel_family:
+        if self.distro.is_rhel_family:
             return self._check_yum()
-        elif self.distro.is_alpine:
+        if self.distro.is_alpine:
             return self._check_apk()
         return [self.skip(f"Updates check not supported for {self.distro.id}")]
+
+    def _count_update_lines(self, output: str) -> int:
+        return len([line for line in output.splitlines() if line.strip()])
+
+    def _findings_from_count(self, count: int, fix_command: str) -> List[Finding]:
+        if count > 10:
+            return [
+                self.warning(
+                    f"{count} packages can be upgraded",
+                    fix_command=fix_command,
+                )
+            ]
+        if count > 0:
+            return [self.info(f"{count} packages can be upgraded")]
+        return [self.ok("System is up to date")]
 
     def _check_apt(self) -> List[Finding]:
         findings = []
@@ -79,46 +94,24 @@ class UpdatesCheck(BaseCheck):
         return findings
 
     def _check_yum(self) -> List[Finding]:
-        findings = []
-        result = self.execute("yum check-update --quiet 2>/dev/null | wc -l", timeout=30)
-        if not result.success:
-            result = self.execute("dnf check-update --quiet 2>/dev/null | wc -l", timeout=30)
-        if not result.success:
-            findings.append(self.skip("Cannot check for updates (yum/dnf)"))
-            return findings
+        commands = (
+            "yum check-update --quiet 2>/dev/null",
+            "dnf check-update --quiet 2>/dev/null",
+        )
+        for command in commands:
+            result = self.execute(command, timeout=30)
+            if result.not_found:
+                continue
+            if result.return_code in (0, 100):
+                count = self._count_update_lines(result.stdout)
+                return self._findings_from_count(count, "yum update -y || dnf update -y")
 
-        try:
-            count = int(result.stdout.strip())
-            if count > 10:
-                findings.append(
-                    self.warning(
-                        f"{count} packages can be upgraded",
-                        fix_command="yum update -y || dnf update -y",
-                    )
-                )
-            elif count > 0:
-                findings.append(self.info(f"{count} packages can be upgraded"))
-            else:
-                findings.append(self.ok("System is up to date"))
-        except ValueError:
-            findings.append(self.skip("Cannot parse update count"))
-
-        return findings
+        return [self.skip("Cannot check for updates (yum/dnf)")]
 
     def _check_apk(self) -> List[Finding]:
-        findings = []
-        result = self.execute("apk version -l '<' 2>/dev/null | wc -l", timeout=30)
+        result = self.execute("apk version -l '<' 2>/dev/null", timeout=30)
         if not result.success:
-            findings.append(self.skip("Cannot check for updates (apk)"))
-            return findings
+            return [self.skip("Cannot check for updates (apk)")]
 
-        try:
-            count = int(result.stdout.strip())
-            if count > 0:
-                findings.append(self.info(f"{count} packages can be upgraded"))
-            else:
-                findings.append(self.ok("System is up to date"))
-        except ValueError:
-            pass
-
-        return findings
+        count = self._count_update_lines(result.stdout)
+        return self._findings_from_count(count, "apk upgrade")

--- a/src/srvaudit/checks/world_writable.py
+++ b/src/srvaudit/checks/world_writable.py
@@ -5,6 +5,9 @@ from typing import List
 from srvaudit.checks.registry import BaseCheck, check
 from srvaudit.models import Finding
 
+RESULT_LIMIT = 20
+DETAIL_LIMIT = 10
+
 
 @check(name="world_writable", category="persistence")
 class WorldWritableCheck(BaseCheck):
@@ -18,19 +21,26 @@ class WorldWritableCheck(BaseCheck):
             " -not -path '/dev/*'"
             " -not -path '/run/*'"
             " -not -path '/tmp/*'"
-            " 2>/dev/null | head -20"
+            f" 2>/dev/null | head -{RESULT_LIMIT}"
         )
-        if not result.success or not result.stdout.strip():
-            findings.append(self.ok("No world-writable files found"))
+        if not result.stdout.strip():
+            if result.return_code != 0:
+                findings.append(self.skip("find command failed"))
+            else:
+                findings.append(self.ok("No world-writable files found"))
             return findings
 
         files = [f.strip() for f in result.stdout.splitlines() if f.strip()]
 
         if files:
+            details = "\n".join(files[:DETAIL_LIMIT])
+            if len(files) == RESULT_LIMIT:
+                note = f"(showing first {RESULT_LIMIT} results, may be incomplete)"
+                details = f"{details}\n{note}" if details else note
             findings.append(
                 self.warning(
                     f"{len(files)} world-writable file(s) found",
-                    details="\n".join(files[:10]),
+                    details=details,
                     fix_command=f"chmod o-w {files[0]}",
                 )
             )

--- a/src/srvaudit/cli.py
+++ b/src/srvaudit/cli.py
@@ -10,7 +10,7 @@ from rich.console import Console
 
 from srvaudit import __version__
 from srvaudit.distro import detect_distro, detect_environment
-from srvaudit.models import AuditReport
+from srvaudit.models import AuditReport, Finding, Severity
 from srvaudit.scoring import calculate_score, score_to_grade
 from srvaudit.transport import HostKeyError, ShellTransport, SSHConnectionError
 
@@ -23,8 +23,8 @@ app = typer.Typer(
 console = Console()
 
 
-def _parse_target(target: str) -> tuple:
-    target = target.strip().replace("ssh://", "")
+def _parse_target(target: str) -> tuple[str, str, int]:
+    target = target.strip().replace("ssh://", "", 1)
     if not target:
         raise typer.BadParameter("Target cannot be empty. Use: user@host")
 
@@ -34,7 +34,25 @@ def _parse_target(target: str) -> tuple:
 
     if "@" in host:
         user, host = host.rsplit("@", 1)
-    if ":" in host:
+    if host.startswith("["):
+        end = host.find("]")
+        if end == -1:
+            raise typer.BadParameter("Invalid IPv6 target. Use: user@[host][:port]")
+
+        remainder = host[end + 1 :]
+        host = host[1:end]
+        if remainder.startswith(":"):
+            port_str = remainder[1:]
+            try:
+                port = int(port_str)
+            except ValueError:
+                pass
+        elif remainder:
+            raise typer.BadParameter("Invalid IPv6 target. Use: user@[host][:port]")
+    elif host.count(":") > 1:
+        # Unbracketed IPv6 literal without an explicit port.
+        pass
+    elif ":" in host:
         host, port_str = host.rsplit(":", 1)
         try:
             port = int(port_str)
@@ -45,6 +63,17 @@ def _parse_target(target: str) -> tuple:
         raise typer.BadParameter("Hostname cannot be empty. Use: user@host")
 
     return user, host, port
+
+
+def _make_skip_findings(check_classes: list, reason: str) -> list[Finding]:
+    return [
+        Finding(
+            check=check_cls._check_meta.name,
+            severity=Severity.SKIP,
+            title=f"Skipped: {reason}",
+        )
+        for check_cls in check_classes
+    ]
 
 
 def version_callback(value: bool):
@@ -105,6 +134,7 @@ def scan(
         raise typer.Exit(2)
 
     start = time.monotonic()
+    skipped_without_sudo = []
 
     with transport:
         console.print("[blue]Detecting OS...[/blue]")
@@ -116,10 +146,23 @@ def scan(
 
         check_classes = get_quick_checks() if quick else get_all_checks()
 
-        if not sudo:
-            check_classes = [c for c in check_classes if not c._check_meta.requires_sudo]
+        privileged_checks = [c for c in check_classes if c._check_meta.requires_sudo]
 
         all_findings = []
+        if sudo:
+            if privileged_checks and not transport.check_passwordless_sudo():
+                transport.sudo = False
+                all_findings.extend(
+                    _make_skip_findings(
+                        privileged_checks,
+                        "passwordless sudo not available",
+                    )
+                )
+                check_classes = [c for c in check_classes if not c._check_meta.requires_sudo]
+        else:
+            skipped_without_sudo = privileged_checks
+            check_classes = [c for c in check_classes if not c._check_meta.requires_sudo]
+
         for check_cls in check_classes:
             meta = check_cls._check_meta
             if verbose:
@@ -130,8 +173,6 @@ def scan(
                 all_findings.extend(findings)
             except Exception as e:
                 logging.getLogger("srvaudit").warning(f"Check {meta.name} failed: {e}")
-                from srvaudit.models import Finding, Severity
-
                 all_findings.append(
                     Finding(
                         check=meta.name,
@@ -172,6 +213,12 @@ def scan(
 
             Path(output).write_text(render_json(report), encoding="utf-8")
             console.print(f"[green]Report saved to {output}[/green]")
+
+    if not sudo and skipped_without_sudo:
+        skipped_names = ", ".join(check._check_meta.name for check in skipped_without_sudo)
+        console.print(
+            f"{len(skipped_without_sudo)} checks skipped (need --sudo): {skipped_names}"
+        )
 
     has_critical = any(f.severity.value == "critical" for f in all_findings)
     has_warning = any(f.severity.value == "warning" for f in all_findings)

--- a/src/srvaudit/cli.py
+++ b/src/srvaudit/cli.py
@@ -216,9 +216,7 @@ def scan(
 
     if not sudo and skipped_without_sudo:
         skipped_names = ", ".join(check._check_meta.name for check in skipped_without_sudo)
-        console.print(
-            f"{len(skipped_without_sudo)} checks skipped (need --sudo): {skipped_names}"
-        )
+        console.print(f"{len(skipped_without_sudo)} checks skipped (need --sudo): {skipped_names}")
 
     has_critical = any(f.severity.value == "critical" for f in all_findings)
     has_warning = any(f.severity.value == "warning" for f in all_findings)

--- a/src/srvaudit/transport.py
+++ b/src/srvaudit/transport.py
@@ -4,6 +4,7 @@ import logging
 import re
 import select
 import time
+from typing import Optional
 from uuid import uuid4
 
 import paramiko
@@ -118,12 +119,19 @@ class ShellTransport:
             self.channel.recv(READ_CHUNK)
             time.sleep(0.1)
 
-    def execute(self, command: str, timeout: int = None) -> CommandResult:
+    def execute(
+        self,
+        command: str,
+        timeout: int = None,
+        use_sudo: Optional[bool] = None,
+    ) -> CommandResult:
         t = timeout or self.command_timeout
         marker = f"{MARKER_PREFIX}_{uuid4().hex[:8]}"
 
         cmd = command
-        if self.sudo:
+        if use_sudo is None:
+            use_sudo = self.sudo
+        if use_sudo:
             cmd = f"sudo {cmd}"
 
         wrapped = f"{cmd}; echo {marker}$?{marker}\n"
@@ -147,6 +155,10 @@ class ShellTransport:
             stdout=stdout,
             return_code=return_code,
         )
+
+    def check_passwordless_sudo(self, timeout: int = 5) -> bool:
+        result = self.execute("sudo -n true", timeout=timeout, use_sudo=False)
+        return result.success
 
     def _read_until_marker(self, marker: str, timeout: int) -> str:
         buf = ""

--- a/tests/test_checks/test_audit_fixes.py
+++ b/tests/test_checks/test_audit_fixes.py
@@ -1,0 +1,100 @@
+from srvaudit.checks.capabilities import CapabilitiesCheck
+from srvaudit.checks.cron import CronCheck
+from srvaudit.checks.dotenv import DotenvCheck
+from srvaudit.checks.world_writable import WorldWritableCheck
+from srvaudit.models import DistroInfo, Severity
+from tests.conftest import MockTransport
+
+WORLD_WRITABLE_CMD = (
+    "find / -maxdepth 3 -perm -002 -type f"
+    " -not -path '/proc/*'"
+    " -not -path '/sys/*'"
+    " -not -path '/dev/*'"
+    " -not -path '/run/*'"
+    " -not -path '/tmp/*'"
+    " 2>/dev/null | head -20"
+)
+CAPABILITIES_CMD = "getcap -r / 2>/dev/null | head -50"
+CRON_USERS_CMD = "getent passwd | awk -F: '$7 !~ /(nologin|false)/ {print $1}' | head -20"
+SYSTEM_CRON_CMD = "ls /etc/cron.d/ 2>/dev/null | head -20"
+DOTENV_DIR_CMD = "test -d /var/www"
+DOTENV_FIND_CMD = "find /var/www -maxdepth 3 -name '.env' -type f 2>/dev/null | head -10"
+TRUNCATED_20_NOTE = "(showing first 20 results, may be incomplete)"
+TRUNCATED_50_NOTE = "(showing first 50 results, may be incomplete)"
+TRUNCATED_10_NOTE = "(showing first 10 results, may be incomplete)"
+
+
+def test_world_writable_find_failure_is_skip():
+    transport = MockTransport(
+        {WORLD_WRITABLE_CMD: ""},
+        {WORLD_WRITABLE_CMD: 1},
+    )
+
+    findings = WorldWritableCheck(transport, DistroInfo()).run()
+
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.SKIP
+    assert findings[0].title == "Skipped: find command failed"
+
+
+def test_world_writable_truncation_note_added():
+    files = "\n".join(f"/path/file{i}" for i in range(20))
+    transport = MockTransport({WORLD_WRITABLE_CMD: files})
+
+    findings = WorldWritableCheck(transport, DistroInfo()).run()
+
+    assert len(findings) == 1
+    assert TRUNCATED_20_NOTE in findings[0].details
+
+
+def test_capabilities_truncation_note_added(ubuntu_distro):
+    output = "\n".join(f"/usr/bin/tool{i}=cap_setuid+ep" for i in range(50))
+    transport = MockTransport({CAPABILITIES_CMD: output})
+
+    findings = CapabilitiesCheck(transport, ubuntu_distro).run()
+
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.WARNING
+    assert TRUNCATED_50_NOTE in findings[0].details
+
+
+def test_cron_truncation_note_added(ubuntu_distro):
+    users = "\n".join(f"user{i}" for i in range(1, 21))
+    system_cron_files = "\n".join(f"job{i}" for i in range(1, 21))
+    transport = MockTransport(
+        {
+            CRON_USERS_CMD: users,
+            "crontab -l -u user1 2>/dev/null": "* * * * * /bin/true\n",
+            SYSTEM_CRON_CMD: system_cron_files,
+        }
+    )
+
+    findings = CronCheck(transport, ubuntu_distro).run()
+
+    assert any(
+        f.title.startswith("user1:") and TRUNCATED_20_NOTE in f.details for f in findings
+    )
+    assert any(
+        "system cron files" in f.title and TRUNCATED_20_NOTE in f.details
+        for f in findings
+    )
+
+
+def test_dotenv_truncation_note_added(ubuntu_distro):
+    files = "\n".join(f"/var/www/site{i}/.env" for i in range(10))
+    transport = MockTransport(
+        {
+            DOTENV_DIR_CMD: "",
+            DOTENV_FIND_CMD: files,
+        },
+        {
+            DOTENV_DIR_CMD: 0,
+            DOTENV_FIND_CMD: 0,
+        },
+    )
+
+    findings = DotenvCheck(transport, ubuntu_distro).run()
+
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.WARNING
+    assert TRUNCATED_10_NOTE in findings[0].details

--- a/tests/test_checks/test_audit_fixes.py
+++ b/tests/test_checks/test_audit_fixes.py
@@ -71,13 +71,8 @@ def test_cron_truncation_note_added(ubuntu_distro):
 
     findings = CronCheck(transport, ubuntu_distro).run()
 
-    assert any(
-        f.title.startswith("user1:") and TRUNCATED_20_NOTE in f.details for f in findings
-    )
-    assert any(
-        "system cron files" in f.title and TRUNCATED_20_NOTE in f.details
-        for f in findings
-    )
+    assert any(f.title.startswith("user1:") and TRUNCATED_20_NOTE in f.details for f in findings)
+    assert any("system cron files" in f.title and TRUNCATED_20_NOTE in f.details for f in findings)
 
 
 def test_dotenv_truncation_note_added(ubuntu_distro):

--- a/tests/test_checks/test_fail2ban.py
+++ b/tests/test_checks/test_fail2ban.py
@@ -22,6 +22,5 @@ def test_detects_exposed_ssh_on_nonstandard_port(ubuntu_distro):
     findings = Fail2banCheck(transport, ubuntu_distro).run()
 
     assert any(
-        f.severity == Severity.WARNING and "fail2ban is not installed" in f.title
-        for f in findings
+        f.severity == Severity.WARNING and "fail2ban is not installed" in f.title for f in findings
     )

--- a/tests/test_checks/test_fail2ban.py
+++ b/tests/test_checks/test_fail2ban.py
@@ -1,0 +1,27 @@
+from srvaudit.checks.fail2ban import Fail2banCheck
+from srvaudit.models import Severity
+from tests.conftest import MockTransport
+
+
+def test_detects_exposed_ssh_on_nonstandard_port(ubuntu_distro):
+    transport = MockTransport(
+        {
+            "fail2ban-client status 2>/dev/null": "",
+            "which fail2ban-server 2>/dev/null": "",
+            "ss -tlnp 2>/dev/null | grep sshd": (
+                'LISTEN 0 128 0.0.0.0:2222 0.0.0.0:* users:(("sshd",pid=123,fd=3))'
+            ),
+        },
+        {
+            "fail2ban-client status 2>/dev/null": 127,
+            "which fail2ban-server 2>/dev/null": 127,
+            "ss -tlnp 2>/dev/null | grep sshd": 0,
+        },
+    )
+
+    findings = Fail2banCheck(transport, ubuntu_distro).run()
+
+    assert any(
+        f.severity == Severity.WARNING and "fail2ban is not installed" in f.title
+        for f in findings
+    )

--- a/tests/test_checks/test_updates.py
+++ b/tests/test_checks/test_updates.py
@@ -1,0 +1,63 @@
+from srvaudit.checks.updates import UpdatesCheck
+from srvaudit.models import Severity
+from tests.conftest import MockTransport
+
+COMMAND_YUM = "yum check-update --quiet 2>/dev/null"
+COMMAND_DNF = "dnf check-update --quiet 2>/dev/null"
+COMMAND_APK = "apk version -l '<' 2>/dev/null"
+
+
+def test_yum_fallback_to_dnf_counts_lines(centos_distro):
+    transport = MockTransport(
+        {
+            COMMAND_YUM: "",
+            COMMAND_DNF: "pkg1.x86_64 1 repo\npkg2.noarch 2 repo\n",
+        },
+        {
+            COMMAND_YUM: 127,
+            COMMAND_DNF: 100,
+        },
+    )
+
+    findings = UpdatesCheck(transport, centos_distro).run()
+
+    assert any(
+        f.severity == Severity.INFO and "2 packages can be upgraded" in f.title
+        for f in findings
+    )
+
+
+def test_yum_and_dnf_errors_return_skip(centos_distro):
+    transport = MockTransport(
+        {
+            COMMAND_YUM: "error",
+            COMMAND_DNF: "error",
+        },
+        {
+            COMMAND_YUM: 1,
+            COMMAND_DNF: 1,
+        },
+    )
+
+    findings = UpdatesCheck(transport, centos_distro).run()
+
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.SKIP
+    assert "yum/dnf" in findings[0].title
+
+
+def test_apk_counts_lines_without_wc(alpine_distro):
+    transport = MockTransport(
+        {
+            COMMAND_APK: "pkg1\npkg2\npkg3\n",
+        },
+        {
+            COMMAND_APK: 0,
+        },
+    )
+
+    findings = UpdatesCheck(transport, alpine_distro).run()
+
+    assert len(findings) == 1
+    assert findings[0].severity == Severity.INFO
+    assert "3 packages can be upgraded" in findings[0].title

--- a/tests/test_checks/test_updates.py
+++ b/tests/test_checks/test_updates.py
@@ -22,8 +22,7 @@ def test_yum_fallback_to_dnf_counts_lines(centos_distro):
     findings = UpdatesCheck(transport, centos_distro).run()
 
     assert any(
-        f.severity == Severity.INFO and "2 packages can be upgraded" in f.title
-        for f in findings
+        f.severity == Severity.INFO and "2 packages can be upgraded" in f.title for f in findings
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,144 @@
+import json
+import tempfile
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+import srvaudit.checks.registry as registry
+import srvaudit.cli as cli
+import srvaudit.output.terminal as terminal_output
+from srvaudit.cli import _parse_target, app
+from srvaudit.models import CheckMeta, DistroInfo, Environment, Finding, Severity
+
+runner = CliRunner()
+
+
+class _RegularCheck:
+    _check_meta = CheckMeta("regular", "test")
+
+    def __init__(self, transport, distro):
+        self.transport = transport
+
+    def run(self):
+        return [Finding(check="regular", severity=Severity.OK, title="regular ok")]
+
+
+class _SudoCheck:
+    _check_meta = CheckMeta("sudo_check", "test", requires_sudo=True)
+
+    def __init__(self, transport, distro):
+        self.transport = transport
+
+    def run(self):
+        return [Finding(check="sudo_check", severity=Severity.OK, title="sudo ok")]
+
+
+class _SecondSudoCheck:
+    _check_meta = CheckMeta("second_sudo", "test", requires_sudo=True)
+
+    def __init__(self, transport, distro):
+        self.transport = transport
+
+    def run(self):
+        return [Finding(check="second_sudo", severity=Severity.OK, title="sudo ok")]
+
+
+def _fake_distro(_transport):
+    return DistroInfo(id="ubuntu", family="debian")
+
+
+def _fake_environment(_transport):
+    return Environment()
+
+
+def test_parse_target_ipv6_brackets():
+    assert _parse_target("root@[2001:db8::1]") == ("root", "2001:db8::1", 22)
+    assert _parse_target("root@[2001:db8::1]:2222") == ("root", "2001:db8::1", 2222)
+
+
+def test_scan_reports_checks_skipped_without_sudo(monkeypatch):
+    class DummyTransport:
+        def __init__(self, *args, sudo=False, **kwargs):
+            self.sudo = sudo
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def check_passwordless_sudo(self):
+            return True
+
+    monkeypatch.setattr(cli, "ShellTransport", DummyTransport)
+    monkeypatch.setattr(cli, "detect_distro", _fake_distro)
+    monkeypatch.setattr(cli, "detect_environment", _fake_environment)
+    monkeypatch.setattr(
+        registry,
+        "get_all_checks",
+        lambda: [_RegularCheck, _SudoCheck, _SecondSudoCheck],
+    )
+    monkeypatch.setattr(registry, "get_quick_checks", lambda: [_RegularCheck, _SudoCheck])
+    monkeypatch.setattr(terminal_output, "render_terminal", lambda report, verbose=False: None)
+
+    result = runner.invoke(app, ["scan", "root@example.com"])
+
+    assert result.exit_code == 0
+    assert "2 checks skipped (need --sudo): sudo_check, second_sudo" in result.output
+
+
+def test_scan_skips_sudo_checks_when_passwordless_sudo_missing(monkeypatch):
+    seen_sudo = []
+
+    class DummyTransport:
+        def __init__(self, *args, sudo=False, **kwargs):
+            self.sudo = sudo
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def check_passwordless_sudo(self):
+            return False
+
+    class RegularCheck:
+        _check_meta = CheckMeta("regular", "test")
+
+        def __init__(self, transport, distro):
+            self.transport = transport
+
+        def run(self):
+            seen_sudo.append(self.transport.sudo)
+            return [Finding(check="regular", severity=Severity.OK, title="regular ok")]
+
+    monkeypatch.setattr(cli, "ShellTransport", DummyTransport)
+    monkeypatch.setattr(cli, "detect_distro", _fake_distro)
+    monkeypatch.setattr(cli, "detect_environment", _fake_environment)
+    monkeypatch.setattr(registry, "get_all_checks", lambda: [RegularCheck, _SudoCheck])
+    monkeypatch.setattr(registry, "get_quick_checks", lambda: [RegularCheck, _SudoCheck])
+
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as handle:
+        output_path = Path(handle.name)
+
+    result = runner.invoke(
+        app,
+        ["scan", "root@example.com", "--sudo", "--json", "-o", str(output_path)],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    skipped = [finding for finding in data["findings"] if finding["severity"] == "skip"]
+    assert skipped == [
+        {
+            "check": "sudo_check",
+            "severity": "skip",
+            "title": "Skipped: passwordless sudo not available",
+            "details": "",
+            "fix_command": "",
+            "references": [],
+        }
+    ]
+    assert seen_sudo == [False]
+    output_path.unlink()


### PR DESCRIPTION
## Summary
- Fix false OK in world_writable when `find` fails
- Add `sudo -n true` preflight check to prevent hang on password prompt
- Remove `| wc -l` pipe that masks package manager errors
- Detect actual SSH port instead of hardcoding :22 in fail2ban
- Show skipped privileged checks when `--sudo` not used
- Add truncation notes for `head -N` sampling
- Fix IPv6 target parsing for bracketed addresses

## Test plan
- [x] 55 tests passing (12 new)
- [x] ruff check clean
- [ ] Live VPS scan after merge